### PR TITLE
Remove `as.table` logic

### DIFF
--- a/R/facet-sample.R
+++ b/R/facet-sample.R
@@ -61,12 +61,7 @@ FacetSample <- ggproto(
 
     layout <- data.frame(PANEL = factor(id))
 
-    if (params$as.table) {
-      layout$ROW <- as.integer((id - 1L) %/% dims[2] + 1L)
-    } else {
-      layout$ROW <- as.integer(dims[1] - (id - 1L) %/% dims[2])
-    }
-
+    layout$ROW <- as.integer((id - 1L) %/% dims[2] + 1L)
     layout$COL <- as.integer((id - 1L) %% dims[2] + 1L)
 
     layout <- layout[order(layout$PANEL), , drop = FALSE]

--- a/R/facet-strata.R
+++ b/R/facet-strata.R
@@ -82,12 +82,7 @@ FacetStrata <- ggproto(
 
     layout <- data.frame(PANEL = factor(id))
 
-    if (params$as.table) {
-      layout$ROW <- as.integer((id - 1L) %/% dims[2] + 1L)
-    } else {
-      layout$ROW <- as.integer(dims[1] - (id - 1L) %/% dims[2])
-    }
-
+    layout$ROW <- as.integer((id - 1L) %/% dims[2] + 1L)
     layout$COL <- as.integer((id - 1L) %% dims[2] + 1L)
 
     layout <- layout[order(layout$PANEL), , drop = FALSE]


### PR DESCRIPTION
Hi Nick,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We've absorbed the `facet_wrap(as.table)` argument into `facet_wrap(dir)` in https://github.com/tidyverse/ggplot2/pull/5855.
Consequently, there is no `as.table` parameter anymore in downstream innards, causing a kerfuffle in brolgar.
The `brolgar::facet_sample()` and `brolgar::facet_strata()` functions don't have an `as.table` argument, so I figured we could skip over the associated logic anyway.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun